### PR TITLE
Bugfix/op 421 hyperlinks show broken on adw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9
+FROM node:10.7
 
 MAINTAINER datapunt.ois@amsterdam.nl
 

--- a/src/services/util.js
+++ b/src/services/util.js
@@ -8,7 +8,7 @@
  */
 export const filteredText = (text, filterText) => {
   // $& Inserts the matched substring
-  return filterText ? text.replace(RegExp(`(?<!href=[\\S]+)${filterText}`, 'ig'), `<span class="filterText">$&</span>`) : text
+  return filterText ? text.replace(RegExp(`(?<!href=[\\S]*)${filterText}`, 'ig'), `<span class="filterText">$&</span>`) : text
 }
 
 export const toHTML = text => {


### PR DESCRIPTION
RegExp from the previous PR was not supported by the node version of the docker container